### PR TITLE
Migrate benchmark functions from ssrJSON

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,69 @@
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: Align
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 0
+CompactNamespaces: false
+ContinuationIndentWidth: 8
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Right
+ReflowComments: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+UseTab: Never
+SortIncludes: CaseInsensitive
+AlignEscapedNewlines: Left
+InsertNewlineAtEOF: true
+SeparateDefinitionBlocks: Always
+IncludeBlocks: Preserve

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.18)
+project(ssrjson_benchmark LANGUAGES C)
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+
+# ------------------------------------------------------------------------------
+# Build Options for tests and docs
+
+# ------------------------------------------------------------------------------
+# Project Config
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(XcodeProperty)
+
+# ------------------------------------------------------------------------------
+# Search Python Package
+find_package(Python3 COMPONENTS Development)
+
+# check for python3
+if((NOT Python3_INCLUDE_DIRS) OR(NOT Python3_LIBRARIES))
+    message(FATAL_ERROR "Python3 not found")
+endif()
+
+message("Python3_INCLUDE_DIRS = ${Python3_INCLUDE_DIRS}")
+message("Python3_LIBRARIES = ${Python3_LIBRARIES}")
+message("Python3_LIBRARY_DIRS = ${Python3_LIBRARY_DIRS}")
+
+# ------------------------------------------------------------------------------
+# Build Type
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    if(NOT CMAKE_BUILD_TYPE)
+        message(STATUS "No build type selected, default to: Release")
+        set(CMAKE_BUILD_TYPE Release)
+    endif()
+endif()
+
+# ------------------------------------------------------------------------------
+# Global settings
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# ------------------------------------------------------------------------------
+# Libraries
+
+# common definitions
+add_library(commonBuild INTERFACE)
+target_link_libraries(commonBuild INTERFACE ${Python3_LIBRARIES})
+target_include_directories(commonBuild INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> ${Python3_INCLUDE_DIRS})
+if(MSVC)
+    target_compile_options(commonBuild INTERFACE /FAcs)
+endif()
+
+message("CMAKE_C_COMPILER_ID = ${CMAKE_C_COMPILER_ID}")
+message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+message("CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
+
+
+# ------------------------------------------------------------------------------
+# setting up ssrjson_benchmark
+
+# set ssrjson_benchmark src files
+set(SRC_FILES
+    src/benchmark.c
+)
+
+add_library(ssrjson_benchmark SHARED ${SRC_FILES})
+target_link_libraries(ssrjson_benchmark PUBLIC ${Python3_LIBRARIES})
+set_target_properties(ssrjson_benchmark PROPERTIES PREFIX "")
+target_include_directories(ssrjson_benchmark PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> ${Python3_INCLUDE_DIRS})
+
+# ------------------------------------------------------------------------------
+if(XCODE)
+    set(SSRJSON_BENCHMARK_FLAGS)
+    list(APPEND SSRJSON_BENCHMARK_FLAGS "-Wall" "-Wextra" "-Werror" "-pedantic" "-pedantic-errors" "-Wno-psabi")
+
+    set_default_xcode_property(commonBuild)
+    set_xcode_deployment_version(commonBuild "10.13" "12.0" "12.0" "4.0")
+
+    set_xcode_property(commonBuild GCC_C_LANGUAGE_STANDARD "c17")
+    set_xcode_property(commonBuild CLANG_C_LANGUAGE_STANDARD "c17")
+
+    # set_xcode_property(commonBuild CLANG_CXX_LANGUAGE_STANDARD "c++98")
+    set_xcode_property(commonBuild OTHER_CFLAGS[variant=Debug] ${SSRJSON_BENCHMARK_FLAGS})
+    set_xcode_property(commonBuild OTHER_CFLAGS[variant=MinSizeRel] ${SSRJSON_BENCHMARK_FLAGS})
+    set_xcode_property(commonBuild OTHER_CFLAGS[variant=RelWithDebInfo] ${SSRJSON_BENCHMARK_FLAGS})
+    set_xcode_property(commonBuild OTHER_CFLAGS[variant=Release] ${SSRJSON_BENCHMARK_FLAGS})
+
+elseif(MSVC)
+    set(SSRJSON_BENCHMARK_FLAGS)
+    list(APPEND SSRJSON_BENCHMARK_FLAGS "/utf-8")
+
+    target_compile_options(commonBuild INTERFACE ${SSRJSON_BENCHMARK_FLAGS})
+
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|Intel")
+    set(SSRJSON_BENCHMARK_FLAGS)
+
+    if(CMAKE_C_COMPILER_ID MATCHES Clang)
+        # https://github.com/llvm/llvm-project/issues/63963
+        list(APPEND SSRJSON_BENCHMARK_FLAGS "-Wno-constant-logical-operand")
+    endif()
+
+    if(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+        message("Release mode with debug info, enabling maximal optimization and debug symbols")
+        target_compile_options(commonBuild INTERFACE -Werror -Wno-psabi -pedantic -pedantic-errors)
+    elseif(CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
+        message("Release mode, enabling maximal optimization")
+        target_compile_options(commonBuild INTERFACE -Werror -Wno-psabi -pedantic -pedantic-errors)
+    else()
+        target_compile_options(commonBuild INTERFACE -O0 -Wno-psabi)
+
+        message("Debug mode, enabling debug symbols")
+    endif()
+
+    target_compile_options(commonBuild INTERFACE ${SSRJSON_BENCHMARK_FLAGS})
+endif()
+
+# ------------------------------------------------------------------------------
+# Install
+if(APPLE)
+    set_target_properties(ssrjson_benchmark PROPERTIES SUFFIX ".so")
+endif(APPLE)
+
+install(TARGETS ssrjson_benchmark LIBRARY DESTINATION .)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include CMakeLists.txt
+recursive-include src *
+recursive-include cmake *

--- a/cmake/XcodeProperty.cmake
+++ b/cmake/XcodeProperty.cmake
@@ -1,0 +1,134 @@
+# Copyright (C) 2019 Yaoyuan <ibireme@gmail.com>.
+# Released under the MIT License:
+# https://github.com/ibireme/yyjson/blob/master/LICENSE
+
+
+# This module contains some macros for Xcode project.
+# For example:
+# if(XCODE)
+#    set_default_xcode_property(yyjson)
+#    set_xcode_deployment_version(yyjson "10.11" "9.0" "9.0" "2.0")
+#    set_xcode_property(yyjson GCC_C_LANGUAGE_STANDARD "c89")
+#    set_xcode_property(yyjson CLANG_CXX_LANGUAGE_STANDARD "c++98")
+# endif()
+
+
+# Set Xcode property to target
+# For example: set_xcode_property(yyjson GCC_C_LANGUAGE_STANDARD "c89")
+macro(set_xcode_property TARGET XCODE_PROPERTY XCODE_VALUE)
+    set_property(TARGET ${TARGET} PROPERTY XCODE_ATTRIBUTE_${XCODE_PROPERTY} ${XCODE_VALUE})
+endmacro(set_xcode_property)
+
+
+# Set default Xcode properties to target
+# For example: set_default_xcode_property(yyjson)
+macro(set_default_xcode_property TARGET)     
+
+    # Standard   
+    set_xcode_property(${TARGET} GCC_C_LANGUAGE_STANDARD "gnu99")
+    set_xcode_property(${TARGET} CLANG_CXX_LANGUAGE_STANDARD "gnu++11")
+    set_xcode_property(${TARGET} CLANG_CXX_LIBRARY "libc++")
+
+    # Compiler Flags
+    set_xcode_property(${TARGET} OTHER_CFLAGS[variant=Debug] " ")
+    set_xcode_property(${TARGET} OTHER_CFLAGS[variant=MinSizeRel] " ")
+    set_xcode_property(${TARGET} OTHER_CFLAGS[variant=RelWithDebInfo] " ")
+    set_xcode_property(${TARGET} OTHER_CFLAGS[variant=Release] " ")
+    set_xcode_property(${TARGET} OTHER_CPLUSPLUSFLAGS[variant=Debug] "$(OTHER_CFLAGS)")
+    set_xcode_property(${TARGET} OTHER_CPLUSPLUSFLAGS[variant=MinSizeRel] "$(OTHER_CFLAGS)")
+    set_xcode_property(${TARGET} OTHER_CPLUSPLUSFLAGS[variant=RelWithDebInfo] "$(OTHER_CFLAGS)")
+    set_xcode_property(${TARGET} OTHER_CPLUSPLUSFLAGS[variant=Release] "$(OTHER_CFLAGS)")
+    
+    # Macros
+    set_xcode_property(${TARGET} GCC_PREPROCESSOR_DEFINITIONS[variant=Debug] "DEBUG=1")
+    set_xcode_property(${TARGET} GCC_PREPROCESSOR_DEFINITIONS[variant=MinSizeRel] "NDEBUG=1")
+    set_xcode_property(${TARGET} GCC_PREPROCESSOR_DEFINITIONS[variant=RelWithDebInfo] "NDEBUG=1")
+    set_xcode_property(${TARGET} GCC_PREPROCESSOR_DEFINITIONS[variant=Release] "NDEBUG=1")
+
+    # Architectures
+    set_xcode_property(${TARGET} ARCHS "$(ARCHS_STANDARD)")
+    set_xcode_property(${TARGET} ONLY_ACTIVE_ARCH[variant=Debug] "YES")
+    set_xcode_property(${TARGET} ONLY_ACTIVE_ARCH[variant=MinSizeRel] "NO")
+    set_xcode_property(${TARGET} ONLY_ACTIVE_ARCH[variant=RelWithDebInfo] "NO")
+    set_xcode_property(${TARGET} ONLY_ACTIVE_ARCH[variant=Release] "NO")
+    set_xcode_property(${TARGET} SDKROOT "macosx")
+    
+    # Debug Information
+    set_xcode_property(${TARGET} DEBUG_INFORMATION_FORMAT[variant=Debug] "dwarf")
+    set_xcode_property(${TARGET} DEBUG_INFORMATION_FORMAT[variant=MinSizeRel] "dwarf-with-dsym")
+    set_xcode_property(${TARGET} DEBUG_INFORMATION_FORMAT[variant=RelWithDebInfo] "dwarf")
+    set_xcode_property(${TARGET} DEBUG_INFORMATION_FORMAT[variant=Release] "dwarf-with-dsym")
+    set_xcode_property(${TARGET} GCC_GENERATE_DEBUGGING_SYMBOLS[variant=Debug] "YES")
+    set_xcode_property(${TARGET} GCC_GENERATE_DEBUGGING_SYMBOLS[variant=MinSizeRel] "NO")
+    set_xcode_property(${TARGET} GCC_GENERATE_DEBUGGING_SYMBOLS[variant=RelWithDebInfo] "YES")
+    set_xcode_property(${TARGET} GCC_GENERATE_DEBUGGING_SYMBOLS[variant=Release] "NO")
+    set_xcode_property(${TARGET} GCC_NO_COMMON_BLOCKS "YES")
+    
+    # Common Warnings
+    set_xcode_property(${TARGET} CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_DOCUMENTATION_COMMENTS "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_EMPTY_BODY "YES")
+    set_xcode_property(${TARGET} GCC_WARN_SHADOW "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_BOOL_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_CONSTANT_CONVERSION "YES")
+    set_xcode_property(${TARGET} GCC_WARN_64_TO_32_BIT_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_ENUM_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_FLOAT_CONVERSION "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_INT_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_NON_LITERAL_NULL_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_INFINITE_RECURSION "YES")
+    set_xcode_property(${TARGET} GCC_WARN_ABOUT_RETURN_TYPE "YES_ERROR")
+    set_xcode_property(${TARGET} GCC_WARN_ABOUT_MISSING_NEWLINE "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_ASSIGN_ENUM "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER "YES")
+    set_xcode_property(${TARGET} GCC_WARN_SIGN_COMPARE "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_STRICT_PROTOTYPES "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_COMMA "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION "YES") ###
+    set_xcode_property(${TARGET} CLANG_WARN_UNGUARDED_AVAILABILITY "YES_AGGRESSIVE")
+    set_xcode_property(${TARGET} GCC_WARN_UNINITIALIZED_AUTOS "YES_AGGRESSIVE")
+    set_xcode_property(${TARGET} CLANG_WARN_UNREACHABLE_CODE "YES")
+    set_xcode_property(${TARGET} GCC_WARN_UNUSED_FUNCTION "YES")
+    set_xcode_property(${TARGET} GCC_WARN_UNUSED_VALUE "YES")
+    set_xcode_property(${TARGET} GCC_WARN_UNUSED_VARIABLE "YES") ###
+
+    # C++ Warnings
+    set_xcode_property(${TARGET} CLANG_WARN_RANGE_LOOP_ANALYSIS "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_SUSPICIOUS_MOVE "YES")
+
+    # ObjC Warnings
+    set_xcode_property(${TARGET} CLANG_WARN_DIRECT_OBJC_ISA_USAGE "YES_ERROR")
+    set_xcode_property(${TARGET} CLANG_WARN__DUPLICATE_METHOD_MATCH "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_OBJC_LITERAL_CONVERSION "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS "YES")
+    set_xcode_property(${TARGET} GCC_WARN_UNDECLARED_SELECTOR "YES")
+    set_xcode_property(${TARGET} CLANG_WARN_OBJC_ROOT_CLASS "YES_ERROR")
+    set_xcode_property(${TARGET} CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF "YES")
+
+    # ObjC Options
+    set_xcode_property(${TARGET} CLANG_ENABLE_OBJC_ARC "YES")
+    set_xcode_property(${TARGET} CLANG_ENABLE_OBJC_WEAK "YES")
+    set_xcode_property(${TARGET} ENABLE_NS_ASSERTIONS[variant=Debug] "YES")
+    set_xcode_property(${TARGET} ENABLE_NS_ASSERTIONS[variant=MinSizeRel] "NO")
+    set_xcode_property(${TARGET} ENABLE_NS_ASSERTIONS[variant=RelWithDebInfo] "NO")
+    set_xcode_property(${TARGET} ENABLE_NS_ASSERTIONS[variant=Release] "NO")
+
+endmacro(set_default_xcode_property)
+
+
+# Set Xcode deployment version (macOS, iOS, tvOS, watchOS)
+# For example: set_xcode_deployment_version(some_target "10.11" "9.0" "9.0" "2.0")
+macro(set_xcode_deployment_version TARGET macOS iOS tvOS watchOS)
+    set_xcode_property(${TARGET} MACOSX_DEPLOYMENT_TARGET ${macOS})
+    set_xcode_property(${TARGET} IPHONEOS_DEPLOYMENT_TARGET ${iOS})
+    set_xcode_property(${TARGET} TVOS_DEPLOYMENT_TARGET ${tvOS})
+    set_xcode_property(${TARGET} WATCHOS_DEPLOYMENT_TARGET ${watchOS})
+endmacro(set_xcode_deployment_version)
+
+
+# Set Xcode language standard (C, CXX)
+# For example: set_xcode_language_standard(some_target "gnu11" "gnu++17")
+macro(set_xcode_language_standard TARGET C CXX)
+    set_xcode_property(${TARGET} GCC_C_LANGUAGE_STANDARD ${C})
+    set_xcode_property(${TARGET} CLANG_CXX_LANGUAGE_STANDARD ${CXX})
+endmacro(set_xcode_language_standard)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,118 @@
+#  Copyright (c) 2025 Antares <antares0982@gmail.com>
+
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import os
+import shutil
+import subprocess
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+# this is only for publishing
+
+
+def check_version(version_str: str):
+    l = version_str.split(".")
+    for val in l:
+        if not val.isdigit():
+            raise ValueError(f"Invalid version string: {version_str}")
+
+
+def find_version(src_file_content: str):
+    # find macro SSRJSON_BENCHMARK_VERSION
+    prefix = "#define SSRJSON_BENCHMARK_VERSION"
+    for line in src_file_content.splitlines():
+        if line.startswith(prefix):
+            version = line[len(prefix) :].strip()[1:-1]
+            check_version(version)
+            return version
+    raise RuntimeError("Cannot find SSRJSON_BENCHMARK_VERSION in source file")
+
+
+with open("./src/benchmark.c", "r", encoding="utf-8") as f:
+    version_string = find_version(f.read())
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        build_dir = os.path.abspath("build")
+        if not os.path.exists(build_dir):
+            os.makedirs(build_dir)
+        #
+        if os.name == "nt":
+            cmake_cmd = [
+                "cmake",
+                "-DCMAKE_BUILD_TYPE=Release",
+                ".",
+                "-B",
+                "build",
+            ]
+        else:
+            cmake_cmd = [
+                "cmake",
+                "-DCMAKE_BUILD_TYPE=Release",
+                ".",
+                "-B",
+                "build",
+            ]
+        subprocess.check_call(cmake_cmd)
+        #
+        if os.name == "nt":
+            build_cmd = ["cmake", "--build", "build", "--config", "Release"]
+        else:
+            build_cmd = ["cmake", "--build", "build"]
+        subprocess.check_call(build_cmd)
+        #
+        if os.name == "nt":
+            built_filename = "Release/ssrjson_benchmark.dll"
+            target_filename = "ssrjson_benchmark.pyd"
+        else:
+            built_filename = "ssrjson_benchmark.so"
+            target_filename = built_filename
+        #
+        built_path = os.path.join(build_dir, built_filename)
+        if not os.path.exists(built_path):
+            raise RuntimeError(f"Built library not found: {built_path}")
+        #
+        target_dir = self.build_lib
+        if not os.path.exists(target_dir):
+            os.makedirs(target_dir)
+        #
+        target_path = os.path.join(target_dir, target_filename)
+        self.announce(f"Copying {built_path} to {target_path}")
+        print(f"Copying {built_path} to {target_path}")
+        shutil.copyfile(built_path, target_path)
+
+
+setup(
+    name="ssrjson_benchmark",
+    version=version_string,
+    # packages=["ssrjson_benchmark"],
+    ext_modules=[
+        Extension(
+            "ssrjson_benchmark",
+            sources=[],
+        )
+    ],
+    cmdclass={
+        "build_ext": CMakeBuild,
+    }
+)

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -1,0 +1,354 @@
+/*==============================================================================
+ Copyright (c) 2025 Antares <antares0982@gmail.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ *============================================================================*/
+
+#include <Python.h>
+#include <stdbool.h>
+
+#define SSRJSON_BENCHMARK_VERSION "0.0.1"
+
+/** compiler builtin check (since gcc 10.0, clang 2.6, icc 2021) */
+#ifndef has_builtin
+#    ifdef __has_builtin
+#        define has_builtin(x) __has_builtin(x)
+#    else
+#        define has_builtin(x) 0
+#    endif
+#endif
+
+/** unlikely for compiler */
+#ifndef unlikely
+#    if has_builtin(__builtin_expect)
+#        define unlikely(expr) __builtin_expect(!!(expr), 0)
+#    else
+#        define unlikely(expr) (expr)
+#    endif
+#endif
+
+typedef unsigned long long usize;
+#if defined(_WIN32) || defined(_WIN64)
+#    include <windows.h>
+
+inline LARGE_INTEGER _get_frequency(void) {
+    LARGE_INTEGER frequency;
+    QueryPerformanceFrequency(&frequency);
+    return frequency;
+}
+
+usize perf_counter(void) {
+    static LARGE_INTEGER *frequency = NULL;
+    if (!frequency) {
+        frequency = (LARGE_INTEGER *)malloc(sizeof(LARGE_INTEGER));
+        if (!frequency) {
+            return 0;
+        }
+        *frequency = _get_frequency();
+    }
+    LARGE_INTEGER counter;
+    QueryPerformanceCounter(&counter);
+    return (usize)((counter.QuadPart * 1000000000LL) / frequency->QuadPart);
+}
+
+#else
+#    include <time.h>
+
+usize perf_counter(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (usize)ts.tv_sec * 1000000000LL + (usize)ts.tv_nsec;
+}
+
+#endif
+
+typedef struct PyUnicodeNewCallArg {
+    Py_ssize_t size;
+    int kind;
+    Py_UCS4 max_char;
+    bool valid;
+} PyUnicodeNewCallArg;
+
+PyObject *_copy_unicode(PyObject *unicode, PyUnicodeNewCallArg *call_arg) {
+    if (!call_arg->valid) {
+        // create copy of unicode object.
+        int kind = PyUnicode_KIND(unicode);
+        Py_UCS4 max_char;
+        if (kind == 4) {
+            max_char = 0x10ffff;
+        } else if (kind == 2) {
+            max_char = 0xffff;
+        } else if (PyUnicode_IS_ASCII(unicode)) {
+            max_char = 0x7f;
+        } else {
+            max_char = 0xff;
+        }
+        //
+        call_arg->size = PyUnicode_GET_LENGTH(unicode);
+        call_arg->kind = kind;
+        call_arg->max_char = max_char;
+        call_arg->valid = true;
+    }
+
+    PyObject *unicode_copy = PyUnicode_New(call_arg->size, call_arg->max_char);
+    memcpy(PyUnicode_DATA(unicode_copy), PyUnicode_DATA(unicode),
+           call_arg->size * call_arg->kind);
+    return unicode_copy;
+}
+
+PyObject *_parse_additional_args(PyObject *additional_args) {
+    Py_ssize_t new_args_count = 1;
+    if (additional_args) {
+        new_args_count += PyTuple_GET_SIZE(additional_args);
+    }
+    PyObject *new_args = PyTuple_New(new_args_count);
+    if (!new_args) {
+        return NULL;
+    }
+    if (additional_args) {
+        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(additional_args); i++) {
+            PyObject *item = PyTuple_GET_ITEM(additional_args, i);
+            Py_INCREF(item);
+            PyTuple_SET_ITEM(new_args, i + 1, item);
+        }
+    }
+    return new_args;
+}
+
+PyObject *run_unicode_accumulate_benchmark(PyObject *self, PyObject *args,
+                                           PyObject *kwargs) {
+    PyObject *callable;
+    usize repeat;
+    PyObject *unicode;
+    PyObject *additional_args = NULL;
+    static const char *kwlist[] = {"func", "repeat", "unicode", "args", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OKO|O", (char **)kwlist,
+                                     &callable, &repeat, &unicode,
+                                     &additional_args)) {
+        PyErr_SetString(PyExc_TypeError, "Invalid argument");
+        goto fail;
+    }
+    if (!PyCallable_Check(callable)) {
+        PyErr_SetString(PyExc_TypeError, "First argument must be callable");
+        goto fail;
+    }
+    if (!PyUnicode_Check(unicode)) {
+        PyErr_SetString(PyExc_TypeError, "Third argument must be unicode");
+        goto fail;
+    }
+    PyUnicodeNewCallArg call_arg;
+    call_arg.valid = false;
+    usize total = 0;
+    for (usize i = 0; i < repeat; i++) {
+        // create copy of unicode object.
+        PyObject *new_args = _parse_additional_args(additional_args);
+        if (!new_args)
+            goto fail;
+        PyObject *unicode_copy = _copy_unicode(unicode, &call_arg);
+        if (!unicode_copy) {
+            Py_DECREF(new_args);
+            goto fail;
+        }
+        PyTuple_SET_ITEM(new_args, 0, unicode_copy);
+        usize start = perf_counter();
+        PyObject *result = PyObject_Call(callable, new_args, NULL);
+        usize end = perf_counter();
+        assert(unicode_copy->ob_refcnt == 1);
+        Py_DECREF(new_args);
+        unicode_copy = NULL;
+        new_args = NULL;
+        if (unlikely(!result)) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_RuntimeError, "Failed to call callable");
+            }
+            goto fail;
+        } else {
+            Py_DECREF(result);
+        }
+        total += end - start;
+    }
+    return PyLong_FromUnsignedLongLong(total);
+fail:;
+    return NULL;
+}
+
+PyObject *run_object_accumulate_benchmark(PyObject *self, PyObject *args,
+                                          PyObject *kwargs) {
+    PyObject *callable;
+    usize repeat;
+    PyObject *call_args;
+    static const char *kwlist[] = {"func", "repeat", "args", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OKO", (char **)kwlist,
+                                     &callable, &repeat, &call_args)) {
+        PyErr_SetString(PyExc_TypeError, "Invalid argument");
+        goto fail;
+    }
+    if (!PyCallable_Check(callable)) {
+        PyErr_SetString(PyExc_TypeError, "First argument must be callable");
+        goto fail;
+    }
+    if (!PyTuple_Check(call_args)) {
+        PyErr_SetString(PyExc_TypeError, "Third argument must be tuple");
+        goto fail;
+    }
+    usize total = 0;
+    for (usize i = 0; i < repeat; i++) {
+        usize start = perf_counter();
+        PyObject *result = PyObject_Call(callable, call_args, NULL);
+        usize end = perf_counter();
+        if (unlikely(!result)) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_RuntimeError, "Failed to call callable");
+            }
+            goto fail;
+        } else {
+            Py_DECREF(result);
+        }
+        total += end - start;
+    }
+    return PyLong_FromUnsignedLongLong(total);
+fail:;
+    return NULL;
+}
+
+PyObject *run_object_benchmark(PyObject *self, PyObject *args,
+                               PyObject *kwargs) {
+    PyObject *callable;
+    PyObject *call_args;
+    static const char *kwlist[] = {"func", "args", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO", (char **)kwlist,
+                                     &callable, &call_args)) {
+        PyErr_SetString(PyExc_TypeError, "Invalid argument");
+        goto fail;
+    }
+    if (!PyCallable_Check(callable)) {
+        PyErr_SetString(PyExc_TypeError, "First argument must be callable");
+        goto fail;
+    }
+    if (!PyTuple_Check(call_args)) {
+        PyErr_SetString(PyExc_TypeError, "Second argument must be tuple");
+        goto fail;
+    }
+    usize start = perf_counter();
+    PyObject *result = PyObject_Call(callable, call_args, NULL);
+    usize end = perf_counter();
+    if (unlikely(!result)) {
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_RuntimeError, "Failed to call callable");
+        }
+        goto fail;
+    } else {
+        Py_DECREF(result);
+    }
+    usize total;
+    total = end - start;
+    return PyLong_FromUnsignedLongLong(total);
+fail:;
+    return NULL;
+}
+
+PyObject *inspect_pyunicode(PyObject *self, PyObject *args, PyObject *kwargs) {
+    PyObject *unicode;
+    PyObject *t1 = NULL, *t2 = NULL, *t3 = NULL, *t4 = NULL;
+    static const char *kwlist[] = {"unicode", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char **)kwlist,
+                                     &unicode)) {
+        goto fail;
+    }
+    if (!PyUnicode_Check(unicode)) {
+        PyErr_SetString(PyExc_TypeError, "First argument must be unicode");
+        goto fail;
+    }
+    PyASCIIObject *u = (PyASCIIObject *)unicode;
+    int length = u->length;
+    int kind = u->state.kind;
+    int ascii = u->state.ascii;
+    int interned = u->state.interned;
+    t1 = PyLong_FromLong(kind);
+    if (!t1)
+        goto fail;
+    t2 = PyLong_FromLong(kind * length);
+    if (!t2)
+        goto fail;
+    t3 = PyBool_FromLong(ascii);
+    if (!t3)
+        goto fail;
+    t4 = PyBool_FromLong(interned);
+    if (!t4)
+        goto fail;
+    PyObject *ret = PyTuple_New(4);
+    if (!ret)
+        goto fail;
+    PyTuple_SET_ITEM(ret, 0, t1);
+    PyTuple_SET_ITEM(ret, 1, t2);
+    PyTuple_SET_ITEM(ret, 2, t3);
+    PyTuple_SET_ITEM(ret, 3, t4);
+    return ret;
+
+fail:;
+    Py_XDECREF(t1);
+    Py_XDECREF(t2);
+    Py_XDECREF(t3);
+    Py_XDECREF(t4);
+    return NULL;
+}
+
+static PyMethodDef ssrjson_benchmark_methods[] = {
+        {"run_unicode_accumulate_benchmark", (PyCFunction)run_unicode_accumulate_benchmark, METH_VARARGS | METH_KEYWORDS, "Benchmark."},
+        {"run_object_accumulate_benchmark", (PyCFunction)run_object_accumulate_benchmark, METH_VARARGS | METH_KEYWORDS, "Benchmark."},
+        {"run_object_benchmark", (PyCFunction)run_object_benchmark, METH_VARARGS | METH_KEYWORDS, "Benchmark."},
+        {"inspect_pyunicode", (PyCFunction)inspect_pyunicode, METH_VARARGS | METH_KEYWORDS, "Inspect PyUnicode."},
+        {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "ssrjson_benchmark",       /* m_name */
+        0,                         /* m_doc */
+        0,                         /* m_size */
+        ssrjson_benchmark_methods, /* m_methods */
+        NULL,                      /* m_slots */
+        NULL,                      /* m_traverse */
+        NULL,                      /* m_clear */
+        NULL                       /* m_free */
+};
+
+PyMODINIT_FUNC PyInit_ssrjson_benchmark(void) {
+    PyObject *module;
+    // check if module already exists
+    if ((module = PyState_FindModule(&moduledef)) != NULL) {
+        Py_INCREF(module);
+        return module;
+    }
+    // create module
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
+    // add version string
+    {
+        int err = PyModule_AddStringConstant(module, "__version__", SSRJSON_BENCHMARK_VERSION);
+        if (err) {
+            Py_DECREF(module);
+            return NULL;
+        }
+    }
+
+    return module;
+}


### PR DESCRIPTION
The benchmark functions are independent from ssrJSON, so I would like to move them here.

A new PyPI package should be released.

You can test building the package by running `python -m build`, and then manylinux wheels can be built by `auditwheel repair --plat manylinux_2_17_x86_64 dist/*.whl`